### PR TITLE
Give every config a sane default value

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,10 @@ ENV TR_PATH_PREFIX trap-registration
 ENV TR_SESSION_SECRET override_this_value
 ENV TR_API_URL override_this_value
 
+# this variable is required to ensure our cookies are kept secure
+# https://scotthelme.co.uk/tough-cookies/#__secure
+ENV COOKIE_PREFIX __Secure-
+
 # let docker know about our listening port
 EXPOSE $TR_PORT
 

--- a/src/app.js
+++ b/src/app.js
@@ -49,7 +49,7 @@ app.use(
   session({
     // Using the __Secure- prefix to protect our cookies as per
     // https://scotthelme.co.uk/tough-cookies/#__secure
-    name: `${config.cookiePrefix}-trap-registration-session`,
+    name: `${config.cookiePrefix}trap-registration-session`,
     cookie: {
       sameSite: true,
       maxAge: sessionDuration,

--- a/src/config.js
+++ b/src/config.js
@@ -1,17 +1,13 @@
 import assert from 'assert';
 
-// Declare up front what env vars we need to continue and ensure they're set.
-assert(process.env.TR_PORT !== undefined, 'A port number (TR_PORT) is required.');
-assert(process.env.TR_SESSION_SECRET !== undefined, 'A secret for sessions (TR_SESSION_SECRET) is required.');
-assert(process.env.TR_API_URL !== undefined, 'A URL for the trap-registration-api service (TR_API_URL) is required.');
-
+// Grab our config from the env vars, or set some defaults if they're missing.
 const config = Object.freeze({
-  port: process.env.TR_PORT,
-  sessionSecret: process.env.TR_SESSION_SECRET,
-  apiEndpoint: process.env.TR_API_URL,
-  hostPrefix: process.env.TR_HOST_PREFIX ? `${process.env.TR_HOST_PREFIX}` : `http://localhost:${process.env.TR_PORT}`,
+  port: process.env.TR_PORT || '3000',
+  sessionSecret: process.env.TR_SESSION_SECRET || 'override_this_value',
+  apiEndpoint: process.env.TR_API_URL || 'http://localhost:3001/trap-registration-api/v1',
+  hostPrefix: process.env.TR_HOST_PREFIX || `http://localhost:${process.env.TR_PORT}`,
   pathPrefix: process.env.TR_PATH_PREFIX ? `/${process.env.TR_PATH_PREFIX}` : '/trap-registration',
-  cookiePrefix: process.env.COOKIE_PREFIX || '__Secure'
+  cookiePrefix: process.env.COOKIE_PREFIX || ''
 });
 
 export {config as default};


### PR DESCRIPTION
This is not (necessarily) the values the project needs to run in production, but the values that are 'good enough' to let you execute `npm run start` without any further configuration.