### PR TITLE
feature/switch-postcode-lookup-api

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -8,7 +8,7 @@ const config = Object.freeze({
   hostPrefix: process.env.TR_HOST_PREFIX || `http://localhost:${process.env.TR_PORT}`,
   pathPrefix: process.env.TR_PATH_PREFIX ? `/${process.env.TR_PATH_PREFIX}` : '/trap-registration',
   cookiePrefix: process.env.COOKIE_PREFIX || '',
-  gazetteerApiEndpoint: process.env.PC_LOOKUP_API_URL || '',
+  gazetteerApiEndpoint: process.env.PC_LOOKUP_API_URL || ''
 });
 
 export {config as default};

--- a/src/config.js
+++ b/src/config.js
@@ -8,8 +8,7 @@ const config = Object.freeze({
   hostPrefix: process.env.TR_HOST_PREFIX || `http://localhost:${process.env.TR_PORT}`,
   pathPrefix: process.env.TR_PATH_PREFIX ? `/${process.env.TR_PATH_PREFIX}` : '/trap-registration',
   cookiePrefix: process.env.COOKIE_PREFIX || '',
-  gazetteerApiEndpoint: process.env.PC_LOOKUP_API_URL || 'https://cagmap.snh.gov.uk/gazetteer',
-  gazetteerApiKey: process.env.PC_LOOKUP_API_KEY ?? ''
+  gazetteerApiEndpoint: process.env.PC_LOOKUP_API_URL || '',
 });
 
 export {config as default};

--- a/src/utils/gazetteer.js
+++ b/src/utils/gazetteer.js
@@ -13,9 +13,6 @@ const findAddressesByPostcode = async (config, postcode) => {
     params: {
       postcode
     },
-    headers: {
-      'User-Agent': 'NatureScotGullsApplybot/1.0'
-    },
     timeout: 10_000
   });
 
@@ -47,9 +44,6 @@ const findAddressesByUprn = async (config, uprn) => {
   const apiResponse = await axios.get(config.gazetteerApiEndpoint, {
     params: {
       uprn
-    },
-    headers: {
-      'User-Agent': 'NatureScotGullsApplybot/1.0'
     },
     timeout: 10_000
   });
@@ -83,9 +77,6 @@ const findFullAddressesByUprn = async (config, uprn) => {
     params: {
       uprn,
       fieldset: 'all'
-    },
-    headers: {
-      'User-Agent': 'NatureScotGullsApplybot/1.0'
     },
     timeout: 10_000
   });

--- a/src/utils/gazetteer.js
+++ b/src/utils/gazetteer.js
@@ -14,7 +14,6 @@ const findAddressesByPostcode = async (config, postcode) => {
       postcode
     },
     headers: {
-      Authorization: `Bearer ${config.gazetteerApiKey}`,
       'User-Agent': 'NatureScotGullsApplybot/1.0'
     },
     timeout: 10_000
@@ -50,7 +49,6 @@ const findAddressesByUprn = async (config, uprn) => {
       uprn
     },
     headers: {
-      Authorization: `Bearer ${config.gazetteerApiKey}`,
       'User-Agent': 'NatureScotGullsApplybot/1.0'
     },
     timeout: 10_000
@@ -87,7 +85,6 @@ const findFullAddressesByUprn = async (config, uprn) => {
       fieldset: 'all'
     },
     headers: {
-      Authorization: `Bearer ${config.gazetteerApiKey}`,
       'User-Agent': 'NatureScotGullsApplybot/1.0'
     },
     timeout: 10_000


### PR DESCRIPTION
Issue https://github.com/Scottish-Natural-Heritage/Licensing/issues/1888.

GIG are switching off their postcode lookup service in the next couple of weeks, this PR bypasses their proxy and connects directly to the lookup service.

The `POSTCODE_LOOKUP_API_URL` is passed in as an environment variable by Terraform, from the Licensing IaC repo, when it starts up the Docker container.