### PR TITLE
bugfix/fix-erroneous-link

### DIFF
--- a/src/views/_base.njk
+++ b/src/views/_base.njk
@@ -106,7 +106,7 @@
     meta: {
       items: [
         {
-          href: pathPrefix + '/privacy-policy',
+          href: '/cross-service-pages/privacy-policy',
           text: "Privacy"
         },
         {


### PR DESCRIPTION
Updates the link to the privacy policy to point to the cross-service-pages application. No issue raised.