### PR TITLE
Hide expiry date if we have none

### DIFF
--- a/src/views/success.njk
+++ b/src/views/success.njk
@@ -1,14 +1,21 @@
 {% extends "_base.njk" %}
 
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% set successHtml %}
+  Your registration number is<br><strong>{{model.regNo}}</strong><br><br>
+  {% if model.expiryDate %}
+    Expiry date<br><strong>{{model.expiryDate}}</strong>
+  {% endif %}
+{% endset %}
+
 {% block content %}
 
   {% if not model.alreadyReceivedApplication %}
 
     {{ govukPanel({
       titleText: "Registration complete",
-      html: "Your registration number is<br><strong>"+model.regNo+"</strong><br><br>" +
-            "Expiry date<br><strong>"+model.expiryDate+"</strong>"
+      html: successHtml
     }) }}
 
   {% endif %}


### PR DESCRIPTION
Note that this code will have no visible effect until the API stops sending out an expiry date - https://github.com/Scottish-Natural-Heritage/Licensing/issues/2415

- This future-proofs us against a change of heart (we will still have an expiry)
- This future-proofs us against switching expiry back on
- Issue https://github.com/Scottish-Natural-Heritage/Licensing/issues/2508