### PR TITLE
Bugfix - handle api date as date

### DIFF
--- a/src/controllers/confirm.js
+++ b/src/controllers/confirm.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import config from '../config.js';
-import {ReturnState} from './_base.js';
 import {formattedDateString} from '../utils/date-utils.js';
+import {ReturnState} from './_base.js';
 
 const confirmController = async (request) => {
   // Grab the form as a json object.

--- a/src/controllers/confirm.js
+++ b/src/controllers/confirm.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import config from '../config.js';
 import {ReturnState} from './_base.js';
+import {formattedDateString} from '../utils/date-utils.js';
 
 const confirmController = async (request) => {
   // Grab the form as a json object.
@@ -46,7 +47,7 @@ const confirmController = async (request) => {
 
     if (newRegResponse.data) {
       request.session.regNo = `NS-TRP-${String(newRegResponse.data.id).padStart(5, '0')}`;
-      request.session.expiryDate = newRegResponse.data.expiryDate;
+      request.session.expiryDate = formattedDateString(newRegResponse.data.expiryDate);
     } else {
       request.session.alreadyReceivedApplication = true;
     }

--- a/src/controllers/renewal-login.js
+++ b/src/controllers/renewal-login.js
@@ -54,7 +54,7 @@ const formatDateForDisplay = (date) => {
 const getRenewalStatus = (date, id) => {
   const renewLink = `${config.pathPrefix}/renewal-check-answers?id=${id}`;
 
-  if (date < monthsFromNow(3) && date > yearsAgo(3)) {
+  if (date && date < monthsFromNow(3) && date > yearsAgo(3)) {
     return `<a class="govuk-link" href="${renewLink}">Renew</a>`;
   }
 
@@ -77,11 +77,12 @@ const getController = async (request) => {
 
     return {
       registrations: trapRegistrationData.map((registration) => {
+        const expiryDate = registration.expiryDate ? new Date(registration.expiryDate) : undefined;
         return [
           {text: `NS-TRP-${registration.id}`},
           {text: registration.addressPostcode},
-          {text: formatDateForDisplay(new Date(registration.expiryDate))},
-          {html: getRenewalStatus(new Date(registration.expiryDate), registration.id)}
+          {text: formatDateForDisplay(expiryDate)},
+          {html: getRenewalStatus(expiryDate, registration.id)}
         ];
       })
     };

--- a/src/utils/date-utils.js
+++ b/src/utils/date-utils.js
@@ -12,4 +12,21 @@ const yearsAgo = (years) => {
   return new Date(currentDate.getFullYear() - years, currentDate.getMonth(), currentDate.getDate());
 };
 
-export {monthsFromNow, yearsAgo};
+const formattedDateString = (dateString) => {
+  if (!dateString) {
+    return undefined;
+  }
+
+  try {
+    const fullDate = new Date(dateString);
+    const d = fullDate.getDate();
+    const m = fullDate.getMonth() + 1;
+    const y = fullDate.getFullYear();
+
+    return `${d}/${m}/${y}`;
+  } catch (error) {
+    return undefined;
+  }
+};
+
+export {monthsFromNow, yearsAgo, formattedDateString};

--- a/src/utils/date-utils.js
+++ b/src/utils/date-utils.js
@@ -24,7 +24,7 @@ const formattedDateString = (dateString) => {
     const y = fullDate.getFullYear();
 
     return `${d}/${m}/${y}`;
-  } catch (error) {
+  } catch {
     return undefined;
   }
 };

--- a/src/views/success.njk
+++ b/src/views/success.njk
@@ -3,9 +3,9 @@
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 
 {% set successHtml %}
-  Your registration number is<br><strong>{{model.regNo}}</strong><br><br>
+  Your registration number is<br><strong>{{model.regNo}}</strong>
   {% if model.expiryDate %}
-    Expiry date<br><strong>{{model.expiryDate}}</strong>
+    <br><br>Expiry date<br><strong>{{model.expiryDate}}</strong>
   {% endif %}
 {% endset %}
 


### PR DESCRIPTION
As the API was sending out a faked expiry as a pre-formatted string, but is now always sending a date or null. Dependent on https://github.com/Scottish-Natural-Heritage/trap-registration-api/pull/127