### PR TITLE
Feature/fix live link

### DIFF
--- a/src/views/_base.njk
+++ b/src/views/_base.njk
@@ -12,61 +12,62 @@
 {% block pageTitle %}NatureScot - Licensing - Trap Registration{% endblock %}
 
 {% block headIcons %}
-  <link rel="shortcut icon" type="image/png" sizes="192x192" href="{{pathPrefix}}/dist/icon-192x192.png">
+	<link rel="shortcut icon" type="image/png" sizes="192x192" href="{{pathPrefix}}/dist/icon-192x192.png">
 
-  <link rel="apple-touch-icon" sizes="192x192" href="{{pathPrefix}}/dist/icon-192x192.png">
-  <link rel="apple-touch-icon" sizes="180x180" href="{{pathPrefix}}/dist/icon-180x180.png">
-  <link rel="apple-touch-icon" sizes="167x167" href="{{pathPrefix}}/dist/icon-167x167.png">
-  <link rel="apple-touch-icon" sizes="152x152" href="{{pathPrefix}}/dist/icon-152x152.png">
-  <link rel="apple-touch-icon" href="{{pathPrefix}}/dist/icon-120x120.png">
+	<link rel="apple-touch-icon" sizes="192x192" href="{{pathPrefix}}/dist/icon-192x192.png">
+	<link rel="apple-touch-icon" sizes="180x180" href="{{pathPrefix}}/dist/icon-180x180.png">
+	<link rel="apple-touch-icon" sizes="167x167" href="{{pathPrefix}}/dist/icon-167x167.png">
+	<link rel="apple-touch-icon" sizes="152x152" href="{{pathPrefix}}/dist/icon-152x152.png">
+	<link rel="apple-touch-icon" href="{{pathPrefix}}/dist/icon-120x120.png">
 
-  <link rel="canonical" href="{{pathPrefix}}" />
-  <meta name="description" content="Use this service to register using a Larsen trap, a Larsen mate trap, a Larsen pod trap, or a multi-catch cage trap under NatureScot's General Licences.">
+	<link rel="canonical" href="{{pathPrefix}}/start"/>
+	<meta name="description" content="Use this service to register using a Larsen trap, a Larsen mate trap, a Larsen pod trap, or a multi-catch cage trap under NatureScot's General Licences.">
 
-  <!-- OpenGraph Data -->
-  <meta property="og:title" content="NatureScot - Licensing - Trap Registration">
-  <meta property="og:type" content="website">
-  <meta property="og:image" content="{{pathPrefix}}/dist/naturescot-opengraph-image.png">
-  <meta property="og:url" content="{{pathPrefix}}">
-  <meta property="og:site_name" content="NatureScot - Licensing">
-  <meta property="og:description" content="Use this service to register using a Larsen trap, a Larsen mate trap, a Larsen pod trap, or a multi-catch cage trap under NatureScot's General Licences.">
-  <meta property="og:image:width" content="1039">
-  <meta property="og:image:height" content="544">
-  <meta property="og:image:alt" content="NatureScot Logo">
+	<!-- OpenGraph Data -->
+	<meta property="og:title" content="NatureScot - Licensing - Trap Registration">
+	<meta property="og:type" content="website">
+	<meta property="og:image" content="{{pathPrefix}}/dist/naturescot-opengraph-image.png">
+	<meta property="og:url" content="{{pathPrefix}}">
+	<meta property="og:site_name" content="NatureScot - Licensing">
+	<meta property="og:description" content="Use this service to register using a Larsen trap, a Larsen mate trap, a Larsen pod trap, or a multi-catch cage trap under NatureScot's General Licences.">
+	<meta property="og:image:width" content="1039">
+	<meta property="og:image:height" content="544">
+	<meta property="og:image:alt" content="NatureScot Logo">
 
-  <!-- Twitter Card Data -->
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:site" content="@nature_scot">
+	<!-- Twitter Card Data -->
+	<meta name="twitter:card" content="summary_large_image">
+	<meta name="twitter:site" content="@nature_scot">
 
 {% endblock %}
 
 {% block head %}
-  <link rel="stylesheet" href="{{pathPrefix}}/dist/main.css">
+	<link rel="stylesheet" href="{{pathPrefix}}/dist/main.css">
 {% endblock %}
 
 {% block skipLink %}
-  {{ govukSkipLink({
+	{{ govukSkipLink({
     href: "#main-content",
     text: "Skip to main content"
   }) }}
 {% endblock %}
 
 {% block header %}
-  {% if (not model) or (model and (not model.seenCookie)) %}
-    <div class="naturescot-cookie-bar">
-      <div class="govuk-width-container">
-        <p class="govuk-body">
+	{% if (not model) 
+		or(model and(not model.seenCookie)) %}
+		<div class="naturescot-cookie-bar">
+			<div class="govuk-width-container">
+				<p class="govuk-body">
           NatureScot uses essential session cookies to remember your progress
           through this application.
           <a class="govuk-link" href="https://www.nature.scot/cookie-policy">
             Find out more.
           </a>
-        </p>
-      </div>
-    </div>
-  {% endif %}
+				</p>
+			</div>
+		</div>
+	{% endif %}
 
-  {{ naturescotHeader({
+	{{ naturescotHeader({
     homepageUrl: "https://www.nature.scot/professional-advice/safeguarding-protected-areas-and-species/licensing",
     containerClasses: "govuk-width-container",
     serviceName: "Trap Registration",
@@ -80,29 +81,29 @@
 {% set mainClasses = "app-main-class" %}
 
 <div class="govuk-width-container">
-  {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-  {% block beforeContent %}
-    {{ govukPhaseBanner({
+	{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+	{% block beforeContent %}
+		{{ govukPhaseBanner({
       tag: {
         text: "beta"
       },
       html: 'This is a new service – your <a class="govuk-link" href="https://www.surveymonkey.co.uk/r/HNJQMFC" target="_blank">feedback (opens in new tab)</a> will help us to improve it.'
     }) }}
-    {% if backUrl %}
-      {{ govukBackLink({
+		{% if backUrl %}
+			{{ govukBackLink({
         text: "Back",
         href: pathPrefix + '/' + backUrl
       }) }}
-    {% endif %}
-  {% endblock %}
+		{% endif %}
+	{% endblock %}
 </div>
 
 <div class="govuk-width-container">
-  {% block content %}{% endblock %}
+	{% block content %}{% endblock %}
 </div>
 
 {% block footer %}
-  {{ naturescotFooter({
+	{{ naturescotFooter({
     meta: {
       items: [
         {
@@ -126,6 +127,6 @@
 {% endblock %}
 
 {% block bodyEnd %}
-  <script src="{{pathPrefix}}/govuk-frontend/all.js"></script>
-  <script src="{{pathPrefix}}/dist/init.js"></script>
+	<script src="{{pathPrefix}}/govuk-frontend/all.js"></script>
+	<script src="{{pathPrefix}}/dist/init.js"></script>
 {% endblock %}

--- a/src/views/renewal-intro.njk
+++ b/src/views/renewal-intro.njk
@@ -23,7 +23,7 @@
 
 			<h2 class="govuk-heading-m">Who can apply</h2>
 
-			<p class="govuk-body">This service is for existing registration holders. You must use a different service to <a class="govuk-link" href="https://licensing.nature.scot/trap-registration/start">apply for a new trap registration</a>.</p>
+			<p class="govuk-body">This service is for existing registration holders. You must use a different service to <a class="govuk-link" href= "{{pathPrefix}}/start">apply for a new trap registration</a>.</p>
 
 			<h2 class="govuk-heading-m">Trap registrations are changing</h2>
 


### PR DESCRIPTION
Fixes a bug where the link for applying for a trap registration was going to live rather than the correct environment.

Also fix an issue where the banner link was broken, takes user to /start