### PR TITLE
feature/update-application-use-node-24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 # Builder Stage
 ################################################################################
 
-# we're deploying to the node:20-alpine image, so do our building on it too
-FROM node:20-alpine as builder
+# we're deploying to the node:24-alpine image, so do our building on it too
+FROM node:24-alpine as builder
 
 # node-gyp runs as part of the npm install, so we need to install dependencies
 USER root
@@ -28,8 +28,8 @@ RUN npm ci && npm prune --production
 # Deployable Image
 ################################################################################
 
-# we built on the node:20-alpine image, so we need to deploy on it too
-FROM node:20-alpine
+# we built on the node:24-alpine image, so we need to deploy on it too
+FROM node:24-alpine
 
 # drop back to the non-privileged user for run-time
 WORKDIR /home/node
@@ -45,16 +45,16 @@ COPY --chown=node:node ./dist ./dist
 
 # these variables are for overriding but keep them consistent between image and
 # run
-ENV TR_PORT 3000
-ENV TR_PATH_PREFIX trap-registration
+ENV TR_PORT=3000
+ENV TR_PATH_PREFIX=trap-registration
 
 # these variables are for overriding and they only matter during run
-ENV TR_SESSION_SECRET override_this_value
-ENV TR_API_URL override_this_value
+ENV TR_SESSION_SECRET=override_this_value
+ENV TR_API_URL=override_this_value
 
 # this variable is required to ensure our cookies are kept secure
 # https://scotthelme.co.uk/tough-cookies/#__secure
-ENV COOKIE_PREFIX __Secure-
+ENV COOKIE_PREFIX=__Secure-
 
 # let docker know about our listening port
 EXPOSE $TR_PORT

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "cy:open": "cypress open"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=24.0.0"
   },
   "dependencies": {
     "axios": "^1.10.0",


### PR DESCRIPTION
Node.js 20 reached end-of-life at the end of April.

Updates the Dockerfile to use the `node:24-alpine` image for building and deploying, and updates the `engine` field in package.json to `24`.

Fixes the `LegacyKeyValueFormat` warning in the logs.